### PR TITLE
Export TS client types

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,35 +15,29 @@
     "test": "bun test",
     "prepare": "husky"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "repository": "ronin-co/react-ronin",
   "homepage": "https://github.com/ronin-co/react-ronin",
-  "keywords": [
-    "ronin",
-    "react",
-    "client",
-    "database",
-    "orm"
-  ],
+  "keywords": ["ronin", "react", "client", "database", "orm"],
   "lint-staged": {
-    "**/*": [
-      "bunx @biomejs/biome format --write"
-    ]
+    "**/*": ["bunx @biomejs/biome format --write"]
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.mts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./types": {
+      "import": "./dist/types.js",
+      "require": "./dist/types.cjs",
+      "types": "./dist/types.d.ts"
     }
   },
   "typesVersions": {
     "*": {
-      "*": [
-        "dist/index.d.ts"
-      ]
+      "*": ["dist/index.d.ts"],
+      "types": ["dist/index.d.ts"]
     }
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,12 +15,22 @@
     "test": "bun test",
     "prepare": "husky"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "repository": "ronin-co/react-ronin",
   "homepage": "https://github.com/ronin-co/react-ronin",
-  "keywords": ["ronin", "react", "client", "database", "orm"],
+  "keywords": [
+    "ronin",
+    "react",
+    "client",
+    "database",
+    "orm"
+  ],
   "lint-staged": {
-    "**/*": ["bunx @biomejs/biome format --write"]
+    "**/*": [
+      "bunx @biomejs/biome format --write"
+    ]
   },
   "exports": {
     ".": {
@@ -36,8 +46,12 @@
   },
   "typesVersions": {
     "*": {
-      "*": ["dist/index.d.ts"],
-      "types": ["dist/index.d.ts"]
+      "*": [
+        "dist/index.d.ts"
+      ],
+      "types": [
+        "dist/index.d.ts"
+      ]
     }
   },
   "dependencies": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,3 @@
+export type * from "ronin/types";
+
+export type { RichTextContent } from "./components/rich-text";


### PR DESCRIPTION
To ensure people don't need to use two clients at the same time, we'd like to re-export the types of the TS client from the React client, just like it is the case for the querying methods.