### PR TITLE
Ensure correct type exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "dist/index.d.ts"
       ],
       "types": [
-        "dist/index.d.ts"
+        "dist/types.d.ts"
       ]
     }
   },


### PR DESCRIPTION
This change was missing from https://github.com/ronin-co/react-client/pull/4 and ensures that the exported types are working as expected!