### PR TITLE
Remove 'language' Property from All Elements Except `codeBlock`

### DIFF
--- a/src/components/image.client.tsx
+++ b/src/components/image.client.tsx
@@ -2,8 +2,7 @@
 
 // We are purposefully importing `React` here, as the build output contains
 // references to it, and those would fail if we don't import it explicitly.
-import type React from "react";
-import { forwardRef, useCallback, useRef } from "react";
+import React, { useCallback, useRef, forwardRef } from "react";
 import type { StoredObject } from "ronin/types";
 
 const supportedFitValues = ["fill", "contain", "cover"];

--- a/src/components/rich-text.tsx
+++ b/src/components/rich-text.tsx
@@ -133,7 +133,7 @@ const RichText = ({
         key={richtTextPrefix + String(position)}
       />
     ) : null;
-    let language;
+    let language: string | undefined;
     switch (item.type) {
       case "doc":
         Element = components?.div || "div";

--- a/src/components/rich-text.tsx
+++ b/src/components/rich-text.tsx
@@ -14,7 +14,8 @@ export type RichTextContent =
         | "blockquote"
         | "codeBlock"
         | "bulletList"
-        | "listItem";
+        | "listItem"
+        | "orderedList";
       // If the node is empty in the editor, it won't have `content` set. For
       // example, you might add a new empty paragraph inside the editor.
       content?: RichTextContent[];
@@ -172,6 +173,10 @@ const RichText = ({
         break;
       case "listItem":
         Element = components?.li || "li";
+        break;
+
+      case "orderedList":
+        Element = components?.ol || "ol";
         break;
     }
 

--- a/src/components/rich-text.tsx
+++ b/src/components/rich-text.tsx
@@ -133,7 +133,7 @@ const RichText = ({
         key={richtTextPrefix + String(position)}
       />
     ) : null;
-    let language = "plaintext";
+    let language;
     switch (item.type) {
       case "doc":
         Element = components?.div || "div";
@@ -176,7 +176,7 @@ const RichText = ({
     }
 
     const RenderingElement = Element as FunctionComponent<{
-      language: string;
+      language?: string;
       children: ReactNode;
     }> | null;
 


### PR DESCRIPTION
Previously, all elements rendered with the RichText editor component included a default 'language' property set to 'plaintext.' Furthermore, `ordered lists` can be rendered now!